### PR TITLE
added test_exact_polynomial_approximation_3d

### DIFF
--- a/tests/test_response_surfaces.py
+++ b/tests/test_response_surfaces.py
@@ -146,10 +146,10 @@ class TestResponseSurfaces(TestCase):
         np.random.seed(42)
         X = np.random.normal(size=(20,3))
         X_train = X.copy()
-        f_2d = 2 + 5*X_train[:,0] - 4*X_train[:,1] + 2*X_train[:,2]
+        f_3d = 2 + 5*X_train[:,0] - 4*X_train[:,1] + 2*X_train[:,2]
 
         pr = rs.PolynomialApproximation(N=3)
-        pr.train(X_train, f_2d.reshape((f_2d.size,1)))
+        pr.train(X_train, f_3d.reshape((f_3d.size,1)))
 
 
     def test_exact_rbf_approximation_1d(self):

--- a/tests/test_response_surfaces.py
+++ b/tests/test_response_surfaces.py
@@ -141,6 +141,17 @@ class TestResponseSurfaces(TestCase):
         np.testing.assert_almost_equal(df[:,0].reshape((10,1)), df1_test.reshape((10,1)), decimal=10)
         np.testing.assert_almost_equal(df[:,1].reshape((10,1)), df2_test.reshape((10,1)), decimal=10)
 
+
+    def test_exact_polynomial_approximation_3d(self):
+        np.random.seed(42)
+        X = np.random.normal(size=(20,3))
+        X_train = X.copy()
+        f_2d = 2 + 5*X_train[:,0] - 4*X_train[:,1] + 2*X_train[:,2]
+
+        pr = rs.PolynomialApproximation(N=3)
+        pr.train(X_train, f_2d.reshape((f_2d.size,1)))
+
+
     def test_exact_rbf_approximation_1d(self):
         np.random.seed(42)
         X = np.random.normal(size=(10,2))


### PR DESCRIPTION
I added the function test_exact_polynomial_approximation_3d in test_response_surfaces.py to underline an error in the PolynomialApproximation class. In particular the test raises the exception 'Error creating quadratic coefficients.' in the file utils/response_surfaces.py at line 120. The test fails when there are more than 2 non-zero entries in indices (so in this case in dim = 3 and polynomial degree = 3). It tries to construct the H matrix but fails because of unwritten assumptions on the variable called indices.
I did not understand why H has to be constructed. I saw it is used in the function qphd_subspace(X, f, weights) in the file subspaces.py but I really do not know what it is.
I think the problem can be addressed with an if statement on the subspace type or on the variable indices. 