### PR TITLE
dimension of df in local_linear_gradients

### DIFF
--- a/active_subspaces/gradients.py
+++ b/active_subspaces/gradients.py
@@ -38,9 +38,10 @@ def local_linear_gradients(X, f, p=None, weights=None):
     if weights is None:
         weights = np.ones((M, 1)) / M
 
-    MM = np.minimum(int(np.ceil(10*m*np.log(m))), M)
+    MM = np.minimum(int(np.ceil(10*m*np.log(m)))*100, M)
     logging.getLogger(__name__).debug('Computing {:d} local linear approximations with {:d} points in {:d} dims.'.format(MM, M, m))
     df = np.zeros((MM, m))
+
     for i in range(MM):
         ii = np.random.randint(M)
         x = X[ii,:]

--- a/active_subspaces/gradients.py
+++ b/active_subspaces/gradients.py
@@ -38,7 +38,7 @@ def local_linear_gradients(X, f, p=None, weights=None):
     if weights is None:
         weights = np.ones((M, 1)) / M
 
-    MM = np.minimum(int(np.ceil(10*m*np.log(m))), M-1)
+    MM = np.minimum(int(np.ceil(10*m*np.log(m))), M)
     logging.getLogger(__name__).debug('Computing {:d} local linear approximations with {:d} points in {:d} dims.'.format(MM, M, m))
     df = np.zeros((MM, m))
     for i in range(MM):


### PR DESCRIPTION
Since df has to be a M-by-m matrix I fixed the df initialization editing the following line:

`MM = np.minimum(int(np.ceil(10*m*np.log(m))), M)`.

It is not clear to me why we have to check M against `10*m*np.log(m)`. 