### PR TITLE
Modified __init__ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ nosetests.xml
 # Translations
 *.mo
 .eggs
+
+# Jupyter Checkpoints
+*.ipynb_checkpoints*

--- a/active_subspaces/__init__.py
+++ b/active_subspaces/__init__.py
@@ -1,1 +1,2 @@
 ''' This is the init file.'''
+import utils, domains, gradients, integrals, optimizers, response_surfaces, sdr, subspaces

--- a/active_subspaces/utils/__init__.py
+++ b/active_subspaces/utils/__init__.py
@@ -1,1 +1,1 @@
-
+import designs, misc, plotters, qp_solver, quadrature, response_surfaces, simrunners


### PR DESCRIPTION
Import statements weren't working because of the empty __ini__.py files; I changed them and now 'import active_subspaces as ac' works as it should.